### PR TITLE
[test] バリデーションなしの場合のエラーメッセージ検証を追加

### DIFF
--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Task, type: :model do
     it 'is valid with title, status' do
       @task = FactoryBot.build(:task, content: '', deadline: '')
       expect(@task).to be_valid
+      expect(@task.errors[:title]).to be_empty
+      expect(@task.errors[:content]).to be_empty
     end
     
     # タイトルが未入力であれば、タスク登録できないこと
@@ -35,7 +37,7 @@ RSpec.describe Task, type: :model do
           :re_task, 
           title: 'スーパーで買い物',
           content: '野菜ジュースを買う'
-          )
+        )
           
         expect(@re_task.valid?).to eq(false)
         expect(@re_task.errors[:title]).to include("has already been taken")


### PR DESCRIPTION
バリデーション発生なしの場合のテストケースの場合も
バリデーション エラーメッセージについての検証を追加

テストを実行、テストパスを確認